### PR TITLE
[3.x][PHP8.5] setAccessible() methods of various Reflection objects have been deprecated

### DIFF
--- a/Tests/CryptTest.php
+++ b/Tests/CryptTest.php
@@ -107,7 +107,6 @@ class CryptTest extends TestCase
         $this->object->setKey($key);
 
         $property = (new \ReflectionClass($this->object))->getProperty('key');
-        $property->setAccessible(true);
 
         $this->assertSame($key, $property->getValue($this->object));
     }


### PR DESCRIPTION
### Summary of Changes

> The “Make reflection setAccessible() no-op” RFC in PHP 8.1 made the Reflection*::setAccessible() methods a noop. However it did not deprecate the methods to simplify cross-version compatibility.

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible

### Testing Instructions

Run unit tests `./vendor/bin/phpunit`
- enable max error reporting
- use php 8.5 (latest pre-version 8.5.0rc1)

### Documentation Changes Required

no